### PR TITLE
fix(재무캐시): timezone-aware datetime 비교 오류 수정

### DIFF
--- a/api/kis_financial_cache.py
+++ b/api/kis_financial_cache.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
 from config.pg_helper import pg_connection
@@ -42,7 +42,8 @@ DEFAULT_MAX_AGE_DAYS = 80
 def _is_stale(fetched_at: Optional[datetime], max_age_days: int) -> bool:
     if fetched_at is None:
         return True
-    return (datetime.now() - fetched_at) > timedelta(days=max_age_days)
+    now = datetime.now(timezone.utc) if fetched_at.tzinfo else datetime.now()
+    return (now - fetched_at) > timedelta(days=max_age_days)
 
 
 def _safe_json(raw) -> str:


### PR DESCRIPTION
## Summary
- `api/kis_financial_cache.py`의 `_is_stale()` 함수에서 PostgreSQL `TIMESTAMPTZ` 컬럼이 반환하는 timezone-aware datetime과 `datetime.now()` (naive) 간의 뺄셈 오류 수정
- `fetched_at.tzinfo` 유무를 확인해 aware면 `datetime.now(timezone.utc)`, naive면 기존 `datetime.now()` 사용

## 증상
스크리닝 실행 시 `can't subtract offset-naive and offset-aware datetimes` 오류가 전 종목에서 발생 → 970개 종목이 '1차 필터링 오류'로 전량 탈락 → 포트폴리오 생성 실패

## 변경 내용
```diff
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone

 def _is_stale(fetched_at: Optional[datetime], max_age_days: int) -> bool:
     if fetched_at is None:
         return True
-    return (datetime.now() - fetched_at) > timedelta(days=max_age_days)
+    now = datetime.now(timezone.utc) if fetched_at.tzinfo else datetime.now()
+    return (now - fetched_at) > timedelta(days=max_age_days)
```

## Test plan
- [x] `python scripts/run_screening_only.py` 실행 후 포트폴리오 10개 정상 생성 확인
- [x] 스크리닝 로그에 `1차 필터링 오류` 없음 확인 (970개 통과)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)